### PR TITLE
Remove the run-test bin from the composer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,6 @@
   "config": {
     "bin-dir": "bin"
   },
-  "bin": [
-    "run-tests.sh"
-  ],
   "autoload": {
     "psr-4": {
       "Behat\\PhantomJSExtension\\": "src/"


### PR DESCRIPTION
This script does not make sense when installing the driver as a dependency, so there is no need to ask Composer to install it.