### PR TITLE
Improve the CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,32 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - hhvm
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.4
+      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
+    - php: 5.6
+      env: DEPENDENCIES=dev
+  allow_failures:
+    - php: 7.0
+    - php: hhvm
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - $HOME/.composer/cache/files
+
+before_install:
+  - composer self-update
+  - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+
+install:
+  - composer update $COMPOSER_FLAGS
 
 before_script:
-  - composer self-update
-  - composer install --no-interaction
   - mkdir -p /tmp/jcalderonzumba/phantomjs
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
     }
   ],
   "require": {
-    "php": ">=5.3.1",
+    "php": ">=5.4",
     "behat/mink": "~1.6",
-    "behat/mink-extension": "~2.0@dev",
-    "twig/twig": "~1.0",
+    "behat/mink-extension": "~2.0",
+    "twig/twig": "~1.4",
     "guzzlehttp/guzzle": "~5.0",
     "jcalderonzumba/gastonjs": "1.0.*"
   },
   "require-dev": {
-    "symfony/process": "~2.0",
+    "symfony/process": "~2.3",
     "symfony/phpunit-bridge": "~2.7",
     "phpunit/phpunit": "~4.6",
     "silex/silex": "~1.2"

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
   },
   "require-dev": {
     "symfony/process": "~2.0",
+    "symfony/phpunit-bridge": "~2.7",
     "phpunit/phpunit": "~4.6",
     "silex/silex": "~1.2"
   },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "php": ">=5.4",
     "behat/mink": "~1.6",
     "behat/mink-extension": "~2.0",
-    "twig/twig": "~1.4",
+    "twig/twig": "~1.8",
     "guzzlehttp/guzzle": "~5.0",
     "jcalderonzumba/gastonjs": "1.0.*"
   },

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
   "require-dev": {
     "symfony/process": "~2.3",
     "symfony/phpunit-bridge": "~2.7",
+    "symfony/css-selector": "~2.1",
     "phpunit/phpunit": "~4.6",
     "silex/silex": "~1.2"
   },

--- a/src/driver/BasePhantomJSDriver.php
+++ b/src/driver/BasePhantomJSDriver.php
@@ -30,7 +30,6 @@ class BasePhantomJSDriver extends CoreDriver {
    * @param string $templateCache where we are going to store the templates cache
    */
   public function __construct($phantomHost, $templateCache = null) {
-    \Twig_Autoloader::register();
     $this->phantomHost = $phantomHost;
     $this->browser = new Browser($phantomHost);
     $this->templateLoader = new \Twig_Loader_Filesystem(realpath(__DIR__ . '/Resources/Script'));


### PR DESCRIPTION
- Test against PHP 7 and HHVM
- Test against lowest deps (to ensure that the lower bound is right) and against dev deps (to catch errors before their release when possible)
- Persist only the composer download cache to avoid invalidating for Packagist metadata updates on each build
- Add the Symfony PHPunit bridge to make the testsuite fail when using deprecated APIs