### PR TITLE
Use semver constraint for gastonjs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "behat/mink-extension": "~2.0",
     "twig/twig": "~1.8",
     "guzzlehttp/guzzle": "~5.0",
-    "jcalderonzumba/gastonjs": "1.0.*"
+    "jcalderonzumba/gastonjs": "~1.0"
   },
   "require-dev": {
     "symfony/process": "~2.3",


### PR DESCRIPTION
The dev version of gastonjs is 1.1.x-dev currently (even if the only improvement compared to 1.0.0 is having more documentation for now).