### PR TITLE
Allow upgrade to twig 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": ">=5.4",
     "behat/mink": "~1.6",
-    "twig/twig": "~1.8",
+    "twig/twig": "~1.20|~2.0",
     "jcalderonzumba/gastonjs": "~1.0"
   },
   "require-dev": {


### PR DESCRIPTION
Getting ready for 2.x version and depending on this project prevents composer from upgrading. This change should allow both.