### PR TITLE
Fix the return value of find when elements are not found

### DIFF
--- a/src/PhantomJSDriver.php
+++ b/src/PhantomJSDriver.php
@@ -152,7 +152,7 @@ class PhantomJSDriver extends BasePhantomJSDriver {
     $nodeElements = array();
 
     if (!isset($elements["ids"])) {
-      return null;
+      return array();
     }
 
     foreach ($elements["ids"] as $i => $elementId) {


### PR DESCRIPTION
Returning ``null`` in this method is not allowed