### PR TITLE
Fix wait timeout

### DIFF
--- a/src/JavascriptTrait.php
+++ b/src/JavascriptTrait.php
@@ -37,7 +37,7 @@ trait JavascriptTrait {
    */
   public function wait($timeout, $condition) {
     $start = microtime(true);
-    $end = $start + $timeout / 1000.0;
+    $end = $start + $timeout * 1000.0;
     do {
       $result = $this->browser->evaluate($condition);
       usleep(100000);


### PR DESCRIPTION
Per `Behat\Mink\Driver\DriverInterface::wait()`, `$timeout` must be expressed in milliseconds.
However, in `JavaScriptTrait::wait()`, `$end` is wrongly computed, dividing the milliseconds value by `1000.0` instead of multiplying it.

Because of this, you can get unexpected issues, like elements not present yet in the DOM, even if you use `$session->wait()`.