### PR TITLE
Update the testsuite to use the new mink/driver-testsuite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ vendor/*
 bin/behat
 bin/phantomjs
 bin/phpunit
+bin/mink-test-server
 composer.lock
 tmp/*
 tests/integration/ScreenShotContext.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,13 @@ matrix:
     - php: 7.0
     - php: hhvm
 
+env:
+  global:
+    # Force the mink test server to use PHP 5.6 as HHVM does not provide the builtin webserver
+    - MINK_PHP_BIN=~/.phpenv/versions/5.6/bin/php
+    # Force the mink test server to bin on IPv4, as PhantomJS resolves localhost as IPv4 while PHP seems to prefer resolving it as IPv6 on Travis
+    - MINK_HOST=127.0.0.1:8002
+
 cache:
   directories:
     - $HOME/.composer/cache/files

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -18,22 +18,16 @@ stop_services(){
   sleep 2
 }
 
-star_local_browser(){
+start_local_browser(){
   CURRENT_DIR=$(pwd)
-  cd ${CURRENT_DIR}/vendor/behat/mink/driver-testsuite/web-fixtures
-  if [ "$TRAVIS" = true ]; then
-    echo "Starting webserver fox fixtures...."
-    ~/.phpenv/versions/5.6/bin/php -S 127.0.0.1:6789 > /dev/null 2>&1 &
-  else
-    php -S 127.0.0.1:6789 2>&1 >> /dev/null &
-  fi
+  ${CURRENT_DIR}/bin/mink-test-server > /dev/null 2>&1 &
   sleep 2
 }
 
 mkdir -p /tmp/jcalderonzumba/phantomjs
-stop_services
+stop_services || true
 start_browser_api
-star_local_browser
+start_local_browser
 cd ${CURRENT_DIR}
 ${CURRENT_DIR}/bin/phpunit --configuration integration_tests.xml
 stop_services

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,8 @@
     "jcalderonzumba/gastonjs": "~1.0"
   },
   "require-dev": {
-    "symfony/process": "~2.3",
-    "symfony/phpunit-bridge": "~2.7",
-    "symfony/css-selector": "~2.1",
-    "phpunit/phpunit": "~4.6",
-    "silex/silex": "~1.2"
+    "mink/driver-testsuite": "dev-master",
+    "phpunit/phpunit": "~4.6"
   },
   "config": {
     "bin-dir": "bin"

--- a/integration_tests.xml
+++ b/integration_tests.xml
@@ -1,30 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit colors="true" bootstrap="./tests/integration/bootstrap.php" stopOnFailure="true">
+<phpunit colors="true" bootstrap="vendor/autoload.php" stopOnFailure="true">
     <testsuites>
         <testsuite name="PhantomJS Driver test suite">
             <directory>tests/integration</directory>
-            <file>vendor/behat/mink/driver-testsuite/tests/Basic/BasicAuthTest.php</file>
-            <file>vendor/behat/mink/driver-testsuite/tests/Basic/ContentTest.php</file>
-            <file>vendor/behat/mink/driver-testsuite/tests/Basic/CookieTest.php</file>
-            <file>vendor/behat/mink/driver-testsuite/tests/Basic/ErrorHandlingTest.php</file>
-            <file>vendor/behat/mink/driver-testsuite/tests/Basic/IFrameTest.php</file>
-            <file>vendor/behat/mink/driver-testsuite/tests/Basic/ScreenshotTest.php</file>
-            <file>vendor/behat/mink/driver-testsuite/tests/Basic/TraversingTest.php</file>
-            <file>vendor/behat/mink/driver-testsuite/tests/Basic/VisibilityTest.php</file>
-            <directory>vendor/behat/mink/driver-testsuite/tests/Form</directory>
-            <directory>vendor/behat/mink/driver-testsuite/tests/Js</directory>
+            <file>vendor/mink/driver-testsuite/tests/Basic/BasicAuthTest.php</file>
+            <file>vendor/mink/driver-testsuite/tests/Basic/ContentTest.php</file>
+            <file>vendor/mink/driver-testsuite/tests/Basic/CookieTest.php</file>
+            <file>vendor/mink/driver-testsuite/tests/Basic/ErrorHandlingTest.php</file>
+            <file>vendor/mink/driver-testsuite/tests/Basic/IFrameTest.php</file>
+            <file>vendor/mink/driver-testsuite/tests/Basic/ScreenshotTest.php</file>
+            <file>vendor/mink/driver-testsuite/tests/Basic/TraversingTest.php</file>
+            <file>vendor/mink/driver-testsuite/tests/Basic/VisibilityTest.php</file>
+            <directory>vendor/mink/driver-testsuite/tests/Form</directory>
+            <directory>vendor/mink/driver-testsuite/tests/Js</directory>
             <!-- The following have been disabled and their respective equals added to Custom driver tests -->
-            <!--<directory>vendor/behat/mink/driver-testsuite/tests/Css</directory>-->
-            <!--<file>vendor/behat/mink/driver-testsuite/tests/Basic/StatusCodeTest.php</file>-->
-            <!--<file>vendor/behat/mink/driver-testsuite/tests/Basic/HeaderTest.php</file>-->
-            <!--<file>vendor/behat/mink/driver-testsuite/tests/Basic/NavigationTest.php</file>-->
+            <!--<directory>vendor/mink/driver-testsuite/tests/Css</directory>-->
+            <!--<file>vendor/mink/driver-testsuite/tests/Basic/StatusCodeTest.php</file>-->
+            <!--<file>vendor/mink/driver-testsuite/tests/Basic/HeaderTest.php</file>-->
+            <!--<file>vendor/mink/driver-testsuite/tests/Basic/NavigationTest.php</file>-->
         </testsuite>
     </testsuites>
 
     <php>
         <var name="driver_config_factory" value="Behat\Mink\Tests\Driver\PhantomJSConfig::getInstance"/>
-        <server name="WEB_FIXTURES_HOST" value="http://127.0.0.1:6789"/>
         <!-- where driver will connect to -->
         <server name="DRIVER_URL" value="http://127.0.0.1:8510/"/>
         <server name="TEMPLATE_CACHE_DIR" value="/tmp/jcalderonzumba/phantomjs"/>
@@ -32,7 +31,7 @@
 
     <filter>
         <whitelist>
-            <directory>./src/Behat/Mink/Driver</directory>
+            <directory>./src/</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/integration_tests.xml
+++ b/integration_tests.xml
@@ -5,6 +5,7 @@
         <testsuite name="PhantomJS Driver test suite">
             <directory>tests/integration</directory>
             <file>vendor/mink/driver-testsuite/tests/Basic/BasicAuthTest.php</file>
+            <file>vendor/mink/driver-testsuite/tests/Basic/BestPracticesTest.php</file>
             <file>vendor/mink/driver-testsuite/tests/Basic/ContentTest.php</file>
             <file>vendor/mink/driver-testsuite/tests/Basic/CookieTest.php</file>
             <file>vendor/mink/driver-testsuite/tests/Basic/ErrorHandlingTest.php</file>

--- a/src/BasePhantomJSDriver.php
+++ b/src/BasePhantomJSDriver.php
@@ -4,7 +4,6 @@ namespace Zumba\Mink\Driver;
 
 use Behat\Mink\Driver\CoreDriver;
 use Behat\Mink\Exception\DriverException;
-use Behat\Mink\Session;
 use Zumba\GastonJS\Browser\Browser;
 
 /**
@@ -13,8 +12,6 @@ use Zumba\GastonJS\Browser\Browser;
  */
 class BasePhantomJSDriver extends CoreDriver {
 
-  /** @var  Session */
-  protected $session;
   /** @var  Browser */
   protected $browser;
   /** @var  string */
@@ -70,14 +67,6 @@ class BasePhantomJSDriver extends CoreDriver {
       throw new DriverException("Failed to get elements with given $xpath");
     }
     return $elements;
-  }
-
-  /**
-   * {@inheritdoc}
-   * @param Session $session
-   */
-  public function setSession(Session $session) {
-    $this->session = $session;
   }
 
   /**

--- a/src/PhantomJSDriver.php
+++ b/src/PhantomJSDriver.php
@@ -2,7 +2,6 @@
 
 namespace Zumba\Mink\Driver;
 
-use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\DriverException;
 
 /**
@@ -144,21 +143,21 @@ class PhantomJSDriver extends BasePhantomJSDriver {
   /**
    * Finds elements with specified XPath query.
    * @param string $xpath
-   * @return NodeElement[]
+   * @return string[]
    * @throws DriverException                  When the operation cannot be done
    */
-  public function find($xpath) {
+  protected function findElementXpaths($xpath) {
     $elements = $this->browser->find("xpath", $xpath);
-    $nodeElements = array();
+    $nodeXPaths = array();
 
     if (!isset($elements["ids"])) {
       return array();
     }
 
     foreach ($elements["ids"] as $i => $elementId) {
-      $nodeElements[] = new NodeElement(sprintf('(%s)[%d]', $xpath, $i + 1), $this->session);
+      $nodeXPaths[] = sprintf('(%s)[%d]', $xpath, $i + 1);
     }
-    return $nodeElements;
+    return $nodeXPaths;
   }
 
 }

--- a/tests/integration/bootstrap.php
+++ b/tests/integration/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require_once __DIR__ . '/../../vendor/behat/mink/driver-testsuite/bootstrap.php';


### PR DESCRIPTION
Hi,

We are in the process of extracting the Mink driver testsuite to a dedicated package rather than having it inside Mink itself, to simplify the maintenance. So I updated your driver to use this setup as well to allow us to complete the migration (the last step will be the removal of the driver testsuite from the Mink repo).