### PR TITLE
Ensure that the cleanup of process runs on test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ env:
     - MINK_PHP_BIN=~/.phpenv/versions/5.6/bin/php
     # Force the mink test server to bin on IPv4, as PhantomJS resolves localhost as IPv4 while PHP seems to prefer resolving it as IPv6 on Travis
     - MINK_HOST=127.0.0.1:8002
+    # Avoid restarting the browser api at the end of tests (see bin/run_tests.sh)
+    - MINK_STOP_BROWSER=1
 
 cache:
   directories:
@@ -41,7 +43,3 @@ before_script:
 
 script:
   - bin/run-tests.sh
-
-after_script:
-  - ps axo pid,command | grep phantomjs | grep -v grep | awk '{print $1}' | xargs -I {} kill {}
-  - ps axo pid,command | grep php | grep -v grep | awk '{print $1}' | xargs -I {} kill {}

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 start_browser_api(){
@@ -24,11 +24,18 @@ start_local_browser(){
   sleep 2
 }
 
+function finish() {
+  stop_services
+  if [ -z "$MINK_STOP_BROWSER" ]; then
+    start_browser_api
+  fi
+}
+
+trap finish EXIT
+
 mkdir -p /tmp/jcalderonzumba/phantomjs
 stop_services || true
 start_browser_api
 start_local_browser
 cd ${CURRENT_DIR}
 ${CURRENT_DIR}/bin/phpunit --configuration integration_tests.xml
-stop_services
-start_browser_api


### PR DESCRIPTION
Without this, the mink-test-server process leaks when tests are failing as stop_services was not running.
Setting the ``MINK_STOP_BROWSER`` env variable allows to avoid restarting the browser API after tests (by default, it keeps restarting, as done today, even though I think changing this behavior would make sense to the opposite default).