### PR TITLE
Fix performance issue when JS condition is met

### DIFF
--- a/src/JavascriptTrait.php
+++ b/src/JavascriptTrait.php
@@ -44,6 +44,10 @@ trait JavascriptTrait {
     $end = $start + $timeout / 1000.0;
     do {
       $result = $this->browser->evaluate($condition);
+      if ($result) {
+        // No need to wait any longer when the conidtion is met already.
+        return TRUE;
+      }
       usleep(100000);
     } while (microtime(true) < $end && !$result);
 

--- a/src/JavascriptTrait.php
+++ b/src/JavascriptTrait.php
@@ -45,7 +45,7 @@ trait JavascriptTrait {
     do {
       $result = $this->browser->evaluate($condition);
       if ($result) {
-        // No need to wait any longer when the conidtion is met already.
+        // No need to wait any longer when the condition is met already.
         return TRUE;
       }
       usleep(100000);


### PR DESCRIPTION
I think this is quite a severe performance issue: when a JS condition is met then wait() should return immediately. No need to wait 100ms for nothing.